### PR TITLE
Add lint job to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,25 +17,36 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
-
     name: Tests (Python ${{ matrix.python-version }})
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install tox tox-gh-actions
+      - name: Install test dependencies
+        run: pip install tox tox-gh-actions
       - name: Run tox
         run: tox
+
+  lint:
+    runs-on: ubuntu-latest
+    name: Ruff
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: pip install tox
+      - name: Run checks
+        run: tox -e ruff
 
   release:
     name: django-jinja-markdown Release
     if: github.event_name == 'release' && github.event.action == 'published'
     needs:
       - test
+      - lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +58,7 @@ jobs:
       - name: Build package for upload to PyPI
         run: python -m build .
       - name: Upload the distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.5.0
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Making it a prerequisite for `release` job.

- Currently passing: [runs/14365700393/job/40277936758](https://github.com/janbrasna/django-jinja-markdown/actions/runs/14365700393/job/40277936758)
- Mocked failed checks: [runs/14375480620/job/40306781113](https://github.com/janbrasna/django-jinja-markdown/actions/runs/14375480620/job/40306781113)

_Repurposed from #6_

_(Also bumps and speeds up things, brought over from the PR.)_